### PR TITLE
Disable global artifacts validation

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -640,9 +640,9 @@ func resolveAllVariables(scope map[string]interface{}, tmplStr string) error {
 				// NOTE: this is far from foolproof.
 			} else if strings.HasPrefix(tag, "workflow.outputs.parameters.") && allowAllWorkflowOutputParameterRefs {
 				// Allow runtime resolution of workflow output parameter names
-				// TODO: allow all global artifacts. Downside of it is that the some step can expect global artifacts
-				// but there is no validation that step which produce this global artifacts is executed before
-				// step which consume it.
+				// TODO: allow all global artifacts. The downside of it is that some step can expect global artifacts,
+				// but there is no validation that the step which produce this global artifacts
+				// is executed before the step which consume it.
 			} else if strings.HasPrefix(tag, "workflow.outputs.artifacts.") {
 				// Allow runtime resolution of workflow output artifact names
 			} else if strings.HasPrefix(tag, "outputs.") {
@@ -847,7 +847,6 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 		if err != nil {
 			return errors.InternalWrapError(err)
 		}
-		//fmt.Println(string(stepBytes))
 
 		for _, step := range stepGroup.Steps {
 			aggregate := len(step.WithItems) > 0 || step.WithParam != ""
@@ -860,11 +859,9 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 			}
 		}
 
+		// TODO: here we do not have a full scope and the global artifacts are not available
 		err = resolveAllVariables(scope, string(stepBytes))
 		if err != nil {
-			fmt.Println("-----")
-			fmt.Println(scope)
-
 			return errors.Errorf(errors.CodeBadRequest, "templates.%s.steps %s", tmpl.Name, err.Error())
 		}
 


### PR DESCRIPTION
**Description**

This pull-request is not intended to be merged. This is to show the diff and also document related things.

**Changes**

Introduced changes just do not check if defined global artifact is available or not.

**Desired changes**
Aggregate all artifacts that are available in the current scope. This requires to iterate and validate templates in order in which they will be executed, so if the step expects global artifacts then there should be validation to ensure that the step which produce this global artifacts is executed before the step which consume it.

**Build and push docker image**
1. Build image:
    ```
    make controller-image
    ```
    > **Note:** If you will have problem with permission check this comment: https://github.com/golang/go/issues/14213#issuecomment-229815144

1. Tag image:
    ```
    docker tag argoproj/workflow-controller:latest gcr.io/projectvoltron/argoproj/workflow-controller:v2.12.9-disabled-global-art-validation
    ```

1. Push image
    ```
    docker push gcr.io/projectvoltron/argoproj/workflow-controller:v2.12.9-disabled-global-art-validation
    ```


**NOTE**
For our voltron code-base we use this branch: https://github.com/Project-Voltron/argo-workflows/tree/remove-problem-with-static-svr
as we had to remove the problem with the static file server. We need to rebase with master and check if the problem still occurs.

23.03.2020 (@Trojan295) - I rebased `remove-problem-with-static-svr` on v2.12.10